### PR TITLE
fix: Allow all origins for CORS.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,14 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    cors: {
+      origin: '*',
+      methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      preflightContinue: false,
+      optionsSuccessStatus: 204,
+    },
+  });
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
I was unable to communicate with the backend effectively due to CORS issues. I simply had to pass CORS options to `NestFactory.create` to allow all origins. In a real world scenario we'd obviously refine CORS rules but for this demo it was easiest to just allow all origin domains.l